### PR TITLE
Remove numbers from name

### DIFF
--- a/lib/namae/parser.rb
+++ b/lib/namae/parser.rb
@@ -77,7 +77,7 @@ module_eval(<<'...end parser.y/module_eval...', 'parser.y', 107)
   end
 
   def normalize(string)
-    string = string.strip
+    string = string.match(/\D*/).to_s.strip
     string
   end
 

--- a/spec/namae/parser_spec.rb
+++ b/spec/namae/parser_spec.rb
@@ -149,6 +149,10 @@ module Namae
             expect(parser.parse!('Ichiro')[0].given).to eq('Ichiro')
           end
 
+          it 'removes numbers' do
+            expect(parser.parse!('Ichiro 20156')[0].given).to eq('Ichiro')
+          end
+
           it 'treats "Lord Byron" as a title and family name' do
             expect(parser.parse!('Lord Byron')[0].values_at(:family, :title)).to eq(['Byron', 'Lord'])
           end


### PR DESCRIPTION
Our organizations works with datasets that combine names and numeric ids.  I wrote this to strip the numbers from the name before parsing. 